### PR TITLE
Julia 0.4 compatability

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,0 +1,2 @@
+julia 0.3
+Compat

--- a/src/GDALfuns.jl
+++ b/src/GDALfuns.jl
@@ -4,85 +4,85 @@ include("gdaldefs.jl")
 
 @c Cint GDALGetDataTypeSize (GDALDataType,) libgdal
 @c Cint GDALDataTypeIsComplex (GDALDataType,) libgdal
-@c Ptr{Uint8} GDALGetDataTypeName (GDALDataType,) libgdal
-@c GDALDataType GDALGetDataTypeByName (Ptr{Uint8},) libgdal
+@c Ptr{UInt8} GDALGetDataTypeName (GDALDataType,) libgdal
+@c GDALDataType GDALGetDataTypeByName (Ptr{UInt8},) libgdal
 @c GDALDataType GDALDataTypeUnion (GDALDataType, GDALDataType) libgdal
-@c Ptr{Uint8} GDALGetAsyncStatusTypeName (GDALAsyncStatusType,) libgdal
-@c GDALAsyncStatusType GDALGetAsyncStatusTypeByName (Ptr{Uint8},) libgdal
-@c Ptr{Uint8} GDALGetColorInterpretationName (GDALColorInterp,) libgdal
-@c GDALColorInterp GDALGetColorInterpretationByName (Ptr{Uint8},) libgdal
-@c Ptr{Uint8} GDALGetPaletteInterpretationName (GDALPaletteInterp,) libgdal
+@c Ptr{UInt8} GDALGetAsyncStatusTypeName (GDALAsyncStatusType,) libgdal
+@c GDALAsyncStatusType GDALGetAsyncStatusTypeByName (Ptr{UInt8},) libgdal
+@c Ptr{UInt8} GDALGetColorInterpretationName (GDALColorInterp,) libgdal
+@c GDALColorInterp GDALGetColorInterpretationByName (Ptr{UInt8},) libgdal
+@c Ptr{UInt8} GDALGetPaletteInterpretationName (GDALPaletteInterp,) libgdal
 @c None GDALAllRegister () libgdal
-@c GDALDatasetH GDALCreate (GDALDriverH, Ptr{Uint8}, Cint, Cint, Cint, GDALDataType, Ptr{Ptr{Uint8}}) libgdal
-@c GDALDatasetH GDALCreateCopy (GDALDriverH, Ptr{Uint8}, GDALDatasetH, Cint, Ptr{Ptr{Uint8}}, Ptr{None}, Ptr{None}) libgdal
-@c GDALDriverH GDALIdentifyDriver (Ptr{Uint8}, Ptr{Ptr{Uint8}}) libgdal
-@c GDALDatasetH GDALOpen (Ptr{Uint8}, GDALAccess) libgdal
-@c GDALDatasetH GDALOpenShared (Ptr{Uint8}, GDALAccess) libgdal
+@c GDALDatasetH GDALCreate (GDALDriverH, Ptr{UInt8}, Cint, Cint, Cint, GDALDataType, Ptr{Ptr{UInt8}}) libgdal
+@c GDALDatasetH GDALCreateCopy (GDALDriverH, Ptr{UInt8}, GDALDatasetH, Cint, Ptr{Ptr{UInt8}}, Ptr{Void}, Ptr{Void}) libgdal
+@c GDALDriverH GDALIdentifyDriver (Ptr{UInt8}, Ptr{Ptr{UInt8}}) libgdal
+@c GDALDatasetH GDALOpen (Ptr{UInt8}, GDALAccess) libgdal
+@c GDALDatasetH GDALOpenShared (Ptr{UInt8}, GDALAccess) libgdal
 @c Cint GDALDumpOpenDatasets (Ptr{FILE},) libgdal
-@c GDALDriverH GDALGetDriverByName (Ptr{Uint8},) libgdal
+@c GDALDriverH GDALGetDriverByName (Ptr{UInt8},) libgdal
 @c Cint GDALGetDriverCount () libgdal
 @c GDALDriverH GDALGetDriver (Cint,) libgdal
 @c None GDALDestroyDriver (GDALDriverH,) libgdal
 @c Cint GDALRegisterDriver (GDALDriverH,) libgdal
 @c None GDALDeregisterDriver (GDALDriverH,) libgdal
 @c None GDALDestroyDriverManager () libgdal
-@c CPLErr GDALDeleteDataset (GDALDriverH, Ptr{Uint8}) libgdal
-@c CPLErr GDALRenameDataset (GDALDriverH, Ptr{Uint8}, Ptr{Uint8}) libgdal
-@c CPLErr GDALCopyDatasetFiles (GDALDriverH, Ptr{Uint8}, Ptr{Uint8}) libgdal
-@c Cint GDALValidateCreationOptions (GDALDriverH, Ptr{Ptr{Uint8}}) libgdal
-@c Ptr{Uint8} GDALGetDriverShortName (GDALDriverH,) libgdal
-@c Ptr{Uint8} GDALGetDriverLongName (GDALDriverH,) libgdal
-@c Ptr{Uint8} GDALGetDriverHelpTopic (GDALDriverH,) libgdal
-@c Ptr{Uint8} GDALGetDriverCreationOptionList (GDALDriverH,) libgdal
+@c CPLErr GDALDeleteDataset (GDALDriverH, Ptr{UInt8}) libgdal
+@c CPLErr GDALRenameDataset (GDALDriverH, Ptr{UInt8}, Ptr{UInt8}) libgdal
+@c CPLErr GDALCopyDatasetFiles (GDALDriverH, Ptr{UInt8}, Ptr{UInt8}) libgdal
+@c Cint GDALValidateCreationOptions (GDALDriverH, Ptr{Ptr{UInt8}}) libgdal
+@c Ptr{UInt8} GDALGetDriverShortName (GDALDriverH,) libgdal
+@c Ptr{UInt8} GDALGetDriverLongName (GDALDriverH,) libgdal
+@c Ptr{UInt8} GDALGetDriverHelpTopic (GDALDriverH,) libgdal
+@c Ptr{UInt8} GDALGetDriverCreationOptionList (GDALDriverH,) libgdal
 @c None GDALInitGCPs (Cint, Ptr{GDAL_GCP}) libgdal
 @c None GDALDeinitGCPs (Cint, Ptr{GDAL_GCP}) libgdal
 @c Ptr{GDAL_GCP} GDALDuplicateGCPs (Cint, Ptr{GDAL_GCP}) libgdal
 @c Cint GDALGCPsToGeoTransform (Cint, Ptr{GDAL_GCP}, Ptr{Cdouble}, Cint) libgdal
 @c Cint GDALInvGeoTransform (Ptr{Cdouble}, Ptr{Cdouble}) libgdal
 @c None GDALApplyGeoTransform (Ptr{Cdouble}, Cdouble, Cdouble, Ptr{Cdouble}, Ptr{Cdouble}) libgdal
-@c Ptr{Ptr{Uint8}} GDALGetMetadata (GDALMajorObjectH, Ptr{Uint8}) libgdal
-@c CPLErr GDALSetMetadata (GDALMajorObjectH, Ptr{Ptr{Uint8}}, Ptr{Uint8}) libgdal
-@c Ptr{Uint8} GDALGetMetadataItem (GDALMajorObjectH, Ptr{Uint8}, Ptr{Uint8}) libgdal
-@c CPLErr GDALSetMetadataItem (GDALMajorObjectH, Ptr{Uint8}, Ptr{Uint8}, Ptr{Uint8}) libgdal
-@c Ptr{Uint8} GDALGetDescription (GDALMajorObjectH,) libgdal
-@c None GDALSetDescription (GDALMajorObjectH, Ptr{Uint8}) libgdal
+@c Ptr{Ptr{UInt8}} GDALGetMetadata (GDALMajorObjectH, Ptr{UInt8}) libgdal
+@c CPLErr GDALSetMetadata (GDALMajorObjectH, Ptr{Ptr{UInt8}}, Ptr{UInt8}) libgdal
+@c Ptr{UInt8} GDALGetMetadataItem (GDALMajorObjectH, Ptr{UInt8}, Ptr{UInt8}) libgdal
+@c CPLErr GDALSetMetadataItem (GDALMajorObjectH, Ptr{UInt8}, Ptr{UInt8}, Ptr{UInt8}) libgdal
+@c Ptr{UInt8} GDALGetDescription (GDALMajorObjectH,) libgdal
+@c None GDALSetDescription (GDALMajorObjectH, Ptr{UInt8}) libgdal
 @c GDALDriverH GDALGetDatasetDriver (GDALDatasetH,) libgdal
-@c Ptr{Ptr{Uint8}} GDALGetFileList (GDALDatasetH,) libgdal
+@c Ptr{Ptr{UInt8}} GDALGetFileList (GDALDatasetH,) libgdal
 @c None GDALClose (GDALDatasetH,) libgdal
 @c Cint GDALGetRasterXSize (GDALDatasetH,) libgdal
 @c Cint GDALGetRasterYSize (GDALDatasetH,) libgdal
 @c Cint GDALGetRasterCount (GDALDatasetH,) libgdal
 @c GDALRasterBandH GDALGetRasterBand (GDALDatasetH, Cint) libgdal
-@c CPLErr GDALAddBand (GDALDatasetH, GDALDataType, Ptr{Ptr{Uint8}}) libgdal
-@c GDALAsyncReaderH GDALBeginAsyncReader (GDALDatasetH, Cint, Cint, Cint, Cint, Ptr{None}, Cint, Cint, GDALDataType, Cint, Ptr{Cint}, Cint, Cint, Cint, Ptr{Ptr{Uint8}}) libgdal
+@c CPLErr GDALAddBand (GDALDatasetH, GDALDataType, Ptr{Ptr{UInt8}}) libgdal
+@c GDALAsyncReaderH GDALBeginAsyncReader (GDALDatasetH, Cint, Cint, Cint, Cint, Ptr{Void}, Cint, Cint, GDALDataType, Cint, Ptr{Cint}, Cint, Cint, Cint, Ptr{Ptr{UInt8}}) libgdal
 @c None GDALEndAsyncReader (GDALDatasetH, GDALAsyncReaderH) libgdal
-@c CPLErr GDALDatasetRasterIO (GDALDatasetH, GDALRWFlag, Cint, Cint, Cint, Cint, Ptr{None}, Cint, Cint, GDALDataType, Cint, Ptr{Cint}, Cint, Cint, Cint) libgdal
-@c CPLErr GDALDatasetAdviseRead (GDALDatasetH, Cint, Cint, Cint, Cint, Cint, Cint, GDALDataType, Cint, Ptr{Cint}, Ptr{Ptr{Uint8}}) libgdal
-@c Ptr{Uint8} GDALGetProjectionRef (GDALDatasetH,) libgdal
-@c CPLErr GDALSetProjection (GDALDatasetH, Ptr{Uint8}) libgdal
+@c CPLErr GDALDatasetRasterIO (GDALDatasetH, GDALRWFlag, Cint, Cint, Cint, Cint, Ptr{Void}, Cint, Cint, GDALDataType, Cint, Ptr{Cint}, Cint, Cint, Cint) libgdal
+@c CPLErr GDALDatasetAdviseRead (GDALDatasetH, Cint, Cint, Cint, Cint, Cint, Cint, GDALDataType, Cint, Ptr{Cint}, Ptr{Ptr{UInt8}}) libgdal
+@c Ptr{UInt8} GDALGetProjectionRef (GDALDatasetH,) libgdal
+@c CPLErr GDALSetProjection (GDALDatasetH, Ptr{UInt8}) libgdal
 @c CPLErr GDALGetGeoTransform (GDALDatasetH, Ptr{Cdouble}) libgdal
 @c CPLErr GDALSetGeoTransform (GDALDatasetH, Ptr{Cdouble}) libgdal
 @c Cint GDALGetGCPCount (GDALDatasetH,) libgdal
-@c Ptr{Uint8} GDALGetGCPProjection (GDALDatasetH,) libgdal
+@c Ptr{UInt8} GDALGetGCPProjection (GDALDatasetH,) libgdal
 @c Ptr{GDAL_GCP} GDALGetGCPs (GDALDatasetH,) libgdal
-@c CPLErr GDALSetGCPs (GDALDatasetH, Cint, Ptr{GDAL_GCP}, Ptr{Uint8}) libgdal
-@c Ptr{None} GDALGetInternalHandle (GDALDatasetH, Ptr{Uint8}) libgdal
+@c CPLErr GDALSetGCPs (GDALDatasetH, Cint, Ptr{GDAL_GCP}, Ptr{UInt8}) libgdal
+@c Ptr{Void} GDALGetInternalHandle (GDALDatasetH, Ptr{UInt8}) libgdal
 @c Cint GDALReferenceDataset (GDALDatasetH,) libgdal
 @c Cint GDALDereferenceDataset (GDALDatasetH,) libgdal
-@c CPLErr GDALBuildOverviews (GDALDatasetH, Ptr{Uint8}, Cint, Ptr{Cint}, Cint, Ptr{Cint}, GDALProgressFunc, Ptr{None}) libgdal
+@c CPLErr GDALBuildOverviews (GDALDatasetH, Ptr{UInt8}, Cint, Ptr{Cint}, Cint, Ptr{Cint}, GDALProgressFunc, Ptr{Void}) libgdal
 @c None GDALGetOpenDatasets (Ptr{Ptr{GDALDatasetH}}, Ptr{Cint}) libgdal
 @c Cint GDALGetAccess (GDALDatasetH,) libgdal
 @c None GDALFlushCache (GDALDatasetH,) libgdal
 @c CPLErr GDALCreateDatasetMaskBand (GDALDatasetH, Cint) libgdal
-@c CPLErr GDALDatasetCopyWholeRaster (GDALDatasetH, GDALDatasetH, Ptr{Ptr{Uint8}}, GDALProgressFunc, Ptr{None}) libgdal
-@c CPLErr GDALRasterBandCopyWholeRaster (GDALRasterBandH, GDALRasterBandH, Ptr{Ptr{Uint8}}, GDALProgressFunc, Ptr{None}) libgdal
-@c CPLErr GDALRegenerateOverviews (GDALRasterBandH, Cint, Ptr{GDALRasterBandH}, Ptr{Uint8}, GDALProgressFunc, Ptr{None}) libgdal
+@c CPLErr GDALDatasetCopyWholeRaster (GDALDatasetH, GDALDatasetH, Ptr{Ptr{UInt8}}, GDALProgressFunc, Ptr{Void}) libgdal
+@c CPLErr GDALRasterBandCopyWholeRaster (GDALRasterBandH, GDALRasterBandH, Ptr{Ptr{UInt8}}, GDALProgressFunc, Ptr{Void}) libgdal
+@c CPLErr GDALRegenerateOverviews (GDALRasterBandH, Cint, Ptr{GDALRasterBandH}, Ptr{UInt8}, GDALProgressFunc, Ptr{Void}) libgdal
 @c GDALDataType GDALGetRasterDataType (GDALRasterBandH,) libgdal
 @c None GDALGetBlockSize (GDALRasterBandH, Ptr{Cint}, Ptr{Cint}) libgdal
-@c CPLErr GDALRasterAdviseRead (GDALRasterBandH, Cint, Cint, Cint, Cint, Cint, Cint, GDALDataType, Ptr{Ptr{Uint8}}) libgdal
-@c CPLErr GDALRasterIO (GDALRasterBandH, GDALRWFlag, Cint, Cint, Cint, Cint, Ptr{None}, Cint, Cint, GDALDataType, Cint, Cint) libgdal
-@c CPLErr GDALReadBlock (GDALRasterBandH, Cint, Cint, Ptr{None}) libgdal
-@c CPLErr GDALWriteBlock (GDALRasterBandH, Cint, Cint, Ptr{None}) libgdal
+@c CPLErr GDALRasterAdviseRead (GDALRasterBandH, Cint, Cint, Cint, Cint, Cint, Cint, GDALDataType, Ptr{Ptr{UInt8}}) libgdal
+@c CPLErr GDALRasterIO (GDALRasterBandH, GDALRWFlag, Cint, Cint, Cint, Cint, Ptr{Void}, Cint, Cint, GDALDataType, Cint, Cint) libgdal
+@c CPLErr GDALReadBlock (GDALRasterBandH, Cint, Cint, Ptr{Void}) libgdal
+@c CPLErr GDALWriteBlock (GDALRasterBandH, Cint, Cint, Ptr{Void}) libgdal
 @c Cint GDALGetRasterBandXSize (GDALRasterBandH,) libgdal
 @c Cint GDALGetRasterBandYSize (GDALRasterBandH,) libgdal
 @c GDALAccess GDALGetRasterAccess (GDALRasterBandH,) libgdal
@@ -97,60 +97,60 @@ include("gdaldefs.jl")
 @c GDALRasterBandH GDALGetOverview (GDALRasterBandH, Cint) libgdal
 @c Cdouble GDALGetRasterNoDataValue (GDALRasterBandH, Ptr{Cint}) libgdal
 @c CPLErr GDALSetRasterNoDataValue (GDALRasterBandH, Cdouble) libgdal
-@c Ptr{Ptr{Uint8}} GDALGetRasterCategoryNames (GDALRasterBandH,) libgdal
-@c CPLErr GDALSetRasterCategoryNames (GDALRasterBandH, Ptr{Ptr{Uint8}}) libgdal
+@c Ptr{Ptr{UInt8}} GDALGetRasterCategoryNames (GDALRasterBandH,) libgdal
+@c CPLErr GDALSetRasterCategoryNames (GDALRasterBandH, Ptr{Ptr{UInt8}}) libgdal
 @c Cdouble GDALGetRasterMinimum (GDALRasterBandH, Ptr{Cint}) libgdal
 @c Cdouble GDALGetRasterMaximum (GDALRasterBandH, Ptr{Cint}) libgdal
 @c CPLErr GDALGetRasterStatistics (GDALRasterBandH, Cint, Cint, Ptr{Cdouble}, Ptr{Cdouble}, Ptr{Cdouble}, Ptr{Cdouble}) libgdal
-@c CPLErr GDALComputeRasterStatistics (GDALRasterBandH, Cint, Ptr{Cdouble}, Ptr{Cdouble}, Ptr{Cdouble}, Ptr{Cdouble}, GDALProgressFunc, Ptr{None}) libgdal
+@c CPLErr GDALComputeRasterStatistics (GDALRasterBandH, Cint, Ptr{Cdouble}, Ptr{Cdouble}, Ptr{Cdouble}, Ptr{Cdouble}, GDALProgressFunc, Ptr{Void}) libgdal
 @c CPLErr GDALSetRasterStatistics (GDALRasterBandH, Cdouble, Cdouble, Cdouble, Cdouble) libgdal
-@c Ptr{Uint8} GDALGetRasterUnitType (GDALRasterBandH,) libgdal
-@c CPLErr GDALSetRasterUnitType (GDALRasterBandH, Ptr{Uint8}) libgdal
+@c Ptr{UInt8} GDALGetRasterUnitType (GDALRasterBandH,) libgdal
+@c CPLErr GDALSetRasterUnitType (GDALRasterBandH, Ptr{UInt8}) libgdal
 @c Cdouble GDALGetRasterOffset (GDALRasterBandH, Ptr{Cint}) libgdal
 @c CPLErr GDALSetRasterOffset (GDALRasterBandH, Cdouble) libgdal
 @c Cdouble GDALGetRasterScale (GDALRasterBandH, Ptr{Cint}) libgdal
 @c CPLErr GDALSetRasterScale (GDALRasterBandH, Cdouble) libgdal
 @c None GDALComputeRasterMinMax (GDALRasterBandH, Cint, Ptr{Cdouble}) libgdal
 @c CPLErr GDALFlushRasterCache (GDALRasterBandH,) libgdal
-@c CPLErr GDALGetRasterHistogram (GDALRasterBandH, Cdouble, Cdouble, Cint, Ptr{Cint}, Cint, Cint, GDALProgressFunc, Ptr{None}) libgdal
-@c CPLErr GDALGetDefaultHistogram (GDALRasterBandH, Ptr{Cdouble}, Ptr{Cdouble}, Ptr{Cint}, Ptr{Ptr{Cint}}, Cint, GDALProgressFunc, Ptr{None}) libgdal
+@c CPLErr GDALGetRasterHistogram (GDALRasterBandH, Cdouble, Cdouble, Cint, Ptr{Cint}, Cint, Cint, GDALProgressFunc, Ptr{Void}) libgdal
+@c CPLErr GDALGetDefaultHistogram (GDALRasterBandH, Ptr{Cdouble}, Ptr{Cdouble}, Ptr{Cint}, Ptr{Ptr{Cint}}, Cint, GDALProgressFunc, Ptr{Void}) libgdal
 @c CPLErr GDALSetDefaultHistogram (GDALRasterBandH, Cdouble, Cdouble, Cint, Ptr{Cint}) libgdal
 @c Cint GDALGetRandomRasterSample (GDALRasterBandH, Cint, Ptr{Cfloat}) libgdal
 @c GDALRasterBandH GDALGetRasterSampleOverview (GDALRasterBandH, Cint) libgdal
 @c CPLErr GDALFillRaster (GDALRasterBandH, Cdouble, Cdouble) libgdal
-@c CPLErr GDALComputeBandStats (GDALRasterBandH, Cint, Ptr{Cdouble}, Ptr{Cdouble}, GDALProgressFunc, Ptr{None}) libgdal
-@c CPLErr GDALOverviewMagnitudeCorrection (GDALRasterBandH, Cint, Ptr{GDALRasterBandH}, GDALProgressFunc, Ptr{None}) libgdal
+@c CPLErr GDALComputeBandStats (GDALRasterBandH, Cint, Ptr{Cdouble}, Ptr{Cdouble}, GDALProgressFunc, Ptr{Void}) libgdal
+@c CPLErr GDALOverviewMagnitudeCorrection (GDALRasterBandH, Cint, Ptr{GDALRasterBandH}, GDALProgressFunc, Ptr{Void}) libgdal
 @c GDALRasterAttributeTableH GDALGetDefaultRAT (GDALRasterBandH,) libgdal
 @c CPLErr GDALSetDefaultRAT (GDALRasterBandH, GDALRasterAttributeTableH) libgdal
-@c CPLErr GDALAddDerivedBandPixelFunc (Ptr{Uint8}, GDALDerivedPixelFunc) libgdal
+@c CPLErr GDALAddDerivedBandPixelFunc (Ptr{UInt8}, GDALDerivedPixelFunc) libgdal
 @c GDALRasterBandH GDALGetMaskBand (GDALRasterBandH,) libgdal
 @c Cint GDALGetMaskFlags (GDALRasterBandH,) libgdal
 @c CPLErr GDALCreateMaskBand (GDALRasterBandH, Cint) libgdal
 @c GDALAsyncStatusType GDALARGetNextUpdatedRegion (GDALAsyncReaderH, Cdouble, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}) libgdal
 @c Cint GDALARLockBuffer (GDALAsyncReaderH, Cdouble) libgdal
 @c None GDALARUnlockBuffer (GDALAsyncReaderH,) libgdal
-@c Cint GDALGeneralCmdLineProcessor (Cint, Ptr{Ptr{Ptr{Uint8}}}, Cint) libgdal
-@c None GDALSwapWords (Ptr{None}, Cint, Cint, Cint) libgdal
-@c None GDALCopyWords (Ptr{None}, GDALDataType, Cint, Ptr{None}, GDALDataType, Cint, Cint) libgdal
+@c Cint GDALGeneralCmdLineProcessor (Cint, Ptr{Ptr{Ptr{UInt8}}}, Cint) libgdal
+@c None GDALSwapWords (Ptr{Void}, Cint, Cint, Cint) libgdal
+@c None GDALCopyWords (Ptr{Void}, GDALDataType, Cint, Ptr{Void}, GDALDataType, Cint, Cint) libgdal
 @c None GDALCopyBits (Ptr{GByte}, Cint, Cint, Ptr{GByte}, Cint, Cint, Cint, Cint) libgdal
-@c Cint GDALLoadWorldFile (Ptr{Uint8}, Ptr{Cdouble}) libgdal
-@c Cint GDALReadWorldFile (Ptr{Uint8}, Ptr{Uint8}, Ptr{Cdouble}) libgdal
-@c Cint GDALWriteWorldFile (Ptr{Uint8}, Ptr{Uint8}, Ptr{Cdouble}) libgdal
-@c Cint GDALLoadTabFile (Ptr{Uint8}, Ptr{Cdouble}, Ptr{Ptr{Uint8}}, Ptr{Cint}, Ptr{Ptr{GDAL_GCP}}) libgdal
-@c Cint GDALReadTabFile (Ptr{Uint8}, Ptr{Cdouble}, Ptr{Ptr{Uint8}}, Ptr{Cint}, Ptr{Ptr{GDAL_GCP}}) libgdal
-@c Cint GDALLoadOziMapFile (Ptr{Uint8}, Ptr{Cdouble}, Ptr{Ptr{Uint8}}, Ptr{Cint}, Ptr{Ptr{GDAL_GCP}}) libgdal
-@c Cint GDALReadOziMapFile (Ptr{Uint8}, Ptr{Cdouble}, Ptr{Ptr{Uint8}}, Ptr{Cint}, Ptr{Ptr{GDAL_GCP}}) libgdal
-@c Ptr{Ptr{Uint8}} GDALLoadRPBFile (Ptr{Uint8}, Ptr{Ptr{Uint8}}) libgdal
-@c Ptr{Ptr{Uint8}} GDALLoadRPCFile (Ptr{Uint8}, Ptr{Ptr{Uint8}}) libgdal
-@c CPLErr GDALWriteRPBFile (Ptr{Uint8}, Ptr{Ptr{Uint8}}) libgdal
-@c Ptr{Ptr{Uint8}} GDALLoadIMDFile (Ptr{Uint8}, Ptr{Ptr{Uint8}}) libgdal
-@c CPLErr GDALWriteIMDFile (Ptr{Uint8}, Ptr{Ptr{Uint8}}) libgdal
-@c Ptr{Uint8} GDALDecToDMS (Cdouble, Ptr{Uint8}, Cint) libgdal
+@c Cint GDALLoadWorldFile (Ptr{UInt8}, Ptr{Cdouble}) libgdal
+@c Cint GDALReadWorldFile (Ptr{UInt8}, Ptr{UInt8}, Ptr{Cdouble}) libgdal
+@c Cint GDALWriteWorldFile (Ptr{UInt8}, Ptr{UInt8}, Ptr{Cdouble}) libgdal
+@c Cint GDALLoadTabFile (Ptr{UInt8}, Ptr{Cdouble}, Ptr{Ptr{UInt8}}, Ptr{Cint}, Ptr{Ptr{GDAL_GCP}}) libgdal
+@c Cint GDALReadTabFile (Ptr{UInt8}, Ptr{Cdouble}, Ptr{Ptr{UInt8}}, Ptr{Cint}, Ptr{Ptr{GDAL_GCP}}) libgdal
+@c Cint GDALLoadOziMapFile (Ptr{UInt8}, Ptr{Cdouble}, Ptr{Ptr{UInt8}}, Ptr{Cint}, Ptr{Ptr{GDAL_GCP}}) libgdal
+@c Cint GDALReadOziMapFile (Ptr{UInt8}, Ptr{Cdouble}, Ptr{Ptr{UInt8}}, Ptr{Cint}, Ptr{Ptr{GDAL_GCP}}) libgdal
+@c Ptr{Ptr{UInt8}} GDALLoadRPBFile (Ptr{UInt8}, Ptr{Ptr{UInt8}}) libgdal
+@c Ptr{Ptr{UInt8}} GDALLoadRPCFile (Ptr{UInt8}, Ptr{Ptr{UInt8}}) libgdal
+@c CPLErr GDALWriteRPBFile (Ptr{UInt8}, Ptr{Ptr{UInt8}}) libgdal
+@c Ptr{Ptr{UInt8}} GDALLoadIMDFile (Ptr{UInt8}, Ptr{Ptr{UInt8}}) libgdal
+@c CPLErr GDALWriteIMDFile (Ptr{UInt8}, Ptr{Ptr{UInt8}}) libgdal
+@c Ptr{UInt8} GDALDecToDMS (Cdouble, Ptr{UInt8}, Cint) libgdal
 @c Cdouble GDALPackedDMSToDec (Cdouble,) libgdal
 @c Cdouble GDALDecToPackedDMS (Cdouble,) libgdal
-@c Ptr{Uint8} GDALVersionInfo (Ptr{Uint8},) libgdal
-@c Cint GDALCheckVersion (Cint, Cint, Ptr{Uint8}) libgdal
-@c Cint GDALExtractRPCInfo (Ptr{Ptr{Uint8}}, Ptr{GDALRPCInfo}) libgdal
+@c Ptr{UInt8} GDALVersionInfo (Ptr{UInt8},) libgdal
+@c Cint GDALCheckVersion (Cint, Cint, Ptr{UInt8}) libgdal
+@c Cint GDALExtractRPCInfo (Ptr{Ptr{UInt8}}, Ptr{GDALRPCInfo}) libgdal
 @c GDALColorTableH GDALCreateColorTable (GDALPaletteInterp,) libgdal
 @c None GDALDestroyColorTable (GDALColorTableH,) libgdal
 @c GDALColorTableH GDALCloneColorTable (GDALColorTableH,) libgdal
@@ -163,19 +163,19 @@ include("gdaldefs.jl")
 @c GDALRasterAttributeTableH GDALCreateRasterAttributeTable () libgdal
 @c None GDALDestroyRasterAttributeTable (GDALRasterAttributeTableH,) libgdal
 @c Cint GDALRATGetColumnCount (GDALRasterAttributeTableH,) libgdal
-@c Ptr{Uint8} GDALRATGetNameOfCol (GDALRasterAttributeTableH, Cint) libgdal
+@c Ptr{UInt8} GDALRATGetNameOfCol (GDALRasterAttributeTableH, Cint) libgdal
 @c GDALRATFieldUsage GDALRATGetUsageOfCol (GDALRasterAttributeTableH, Cint) libgdal
 @c GDALRATFieldType GDALRATGetTypeOfCol (GDALRasterAttributeTableH, Cint) libgdal
 @c Cint GDALRATGetColOfUsage (GDALRasterAttributeTableH, GDALRATFieldUsage) libgdal
 @c Cint GDALRATGetRowCount (GDALRasterAttributeTableH,) libgdal
-@c Ptr{Uint8} GDALRATGetValueAsString (GDALRasterAttributeTableH, Cint, Cint) libgdal
+@c Ptr{UInt8} GDALRATGetValueAsString (GDALRasterAttributeTableH, Cint, Cint) libgdal
 @c Cint GDALRATGetValueAsInt (GDALRasterAttributeTableH, Cint, Cint) libgdal
 @c Cdouble GDALRATGetValueAsDouble (GDALRasterAttributeTableH, Cint, Cint) libgdal
-@c None GDALRATSetValueAsString (GDALRasterAttributeTableH, Cint, Cint, Ptr{Uint8}) libgdal
+@c None GDALRATSetValueAsString (GDALRasterAttributeTableH, Cint, Cint, Ptr{UInt8}) libgdal
 @c None GDALRATSetValueAsInt (GDALRasterAttributeTableH, Cint, Cint, Cint) libgdal
 @c None GDALRATSetValueAsDouble (GDALRasterAttributeTableH, Cint, Cint, Cdouble) libgdal
 @c None GDALRATSetRowCount (GDALRasterAttributeTableH, Cint) libgdal
-@c CPLErr GDALRATCreateColumn (GDALRasterAttributeTableH, Ptr{Uint8}, GDALRATFieldType, GDALRATFieldUsage) libgdal
+@c CPLErr GDALRATCreateColumn (GDALRasterAttributeTableH, Ptr{UInt8}, GDALRATFieldType, GDALRATFieldUsage) libgdal
 @c CPLErr GDALRATSetLinearBinning (GDALRasterAttributeTableH, Cdouble, Cdouble) libgdal
 @c Cint GDALRATGetLinearBinning (GDALRasterAttributeTableH, Ptr{Cdouble}, Ptr{Cdouble}) libgdal
 @c CPLErr GDALRATInitializeFromColorTable (GDALRasterAttributeTableH, GDALColorTableH) libgdal

--- a/src/gdaldefs.jl
+++ b/src/gdaldefs.jl
@@ -27,7 +27,7 @@ const GMF_ALPHA = 0x04
 const GMF_NODATA = 0x08
 # Skipping MacroDefinition: GDAL_CHECK_VERSION(pszCallingComponentName)GDALCheckVersion(GDAL_VERSION_MAJOR,GDAL_VERSION_MINOR,pszCallingComponentName)
 # begin enum GDALDataType
-typealias GDALDataType Uint32
+typealias GDALDataType UInt32
 const GDT_Unknown = 0
 const GDT_Byte = 1
 const GDT_UInt16 = 2
@@ -43,7 +43,7 @@ const GDT_CFloat64 = 11
 const GDT_TypeCount = 12
 # end enum GDALDataType
 # begin enum GDALAsyncStatusType
-typealias GDALAsyncStatusType Uint32
+typealias GDALAsyncStatusType UInt32
 const GARIO_PENDING = 0
 const GARIO_UPDATE = 1
 const GARIO_ERROR = 2
@@ -51,17 +51,17 @@ const GARIO_COMPLETE = 3
 const GARIO_TypeCount = 4
 # end enum GDALAsyncStatusType
 # begin enum GDALAccess
-typealias GDALAccess Uint32
+typealias GDALAccess UInt32
 const GA_ReadOnly = 0
 const GA_Update = 1
 # end enum GDALAccess
 # begin enum GDALRWFlag
-typealias GDALRWFlag Uint32
+typealias GDALRWFlag UInt32
 const GF_Read = 0
 const GF_Write = 1
 # end enum GDALRWFlag
 # begin enum GDALColorInterp
-typealias GDALColorInterp Uint32
+typealias GDALColorInterp UInt32
 const GCI_Undefined = 0
 const GCI_GrayIndex = 1
 const GCI_PaletteIndex = 2
@@ -82,29 +82,29 @@ const GCI_YCbCr_CrBand = 16
 const GCI_Max = 16
 # end enum GDALColorInterp
 # begin enum GDALPaletteInterp
-typealias GDALPaletteInterp Uint32
+typealias GDALPaletteInterp UInt32
 const GPI_Gray = 0
 const GPI_RGB = 1
 const GPI_CMYK = 2
 const GPI_HLS = 3
 # end enum GDALPaletteInterp
-typealias GDALMajorObjectH Ptr{None}
-typealias GDALDatasetH Ptr{None}
-typealias GDALRasterBandH Ptr{None}
-typealias GDALDriverH Ptr{None}
-typealias GDALProjDefH Ptr{None}
-typealias GDALColorTableH Ptr{None}
-typealias GDALRasterAttributeTableH Ptr{None}
-typealias GDALAsyncReaderH Ptr{None}
+typealias GDALMajorObjectH Ptr{Void}
+typealias GDALDatasetH Ptr{Void}
+typealias GDALRasterBandH Ptr{Void}
+typealias GDALDriverH Ptr{Void}
+typealias GDALProjDefH Ptr{Void}
+typealias GDALColorTableH Ptr{Void}
+typealias GDALRasterAttributeTableH Ptr{Void}
+typealias GDALAsyncReaderH Ptr{Void}
 typealias GDALDerivedPixelFunc Ptr{Void}
 # begin enum GDALRATFieldType
-typealias GDALRATFieldType Uint32
+typealias GDALRATFieldType UInt32
 const GFT_Integer = 0
 const GFT_Real = 1
 const GFT_String = 2
 # end enum GDALRATFieldType
 # begin enum GDALRATFieldUsage
-typealias GDALRATFieldUsage Uint32
+typealias GDALRATFieldUsage UInt32
 const GFU_Generic = 0
 const GFU_PixelCount = 1
 const GFU_Name = 2
@@ -139,7 +139,7 @@ const INTEROPERABILITYOFFSET = 0xA005
 const GPSOFFSETTAG = 0x8825
 const MAXSTRINGLENGTH = 65535
 # begin enum TIFFDataType
-typealias TIFFDataType Uint32
+typealias TIFFDataType UInt32
 const TIFF_NOTYPE = 0
 const TIFF_BYTE = 1
 const TIFF_ASCII = 2
@@ -156,7 +156,7 @@ const TIFF_DOUBLE = 12
 const TIFF_IFD = 13
 # end enum TIFFDataType
 # begin enum GDALResampleAlg
-typealias GDALResampleAlg Uint32
+typealias GDALResampleAlg UInt32
 const GRA_NearestNeighbour = 0
 const GRA_Bilinear = 1
 const GRA_Cubic = 2
@@ -166,12 +166,12 @@ const GRA_Average = 5
 const GRA_Mode = 6
 # end enum GDALResampleAlg
 typealias GDALMaskFunc Ptr{Void}
-typealias GDALWarpOperationH Ptr{None}
+typealias GDALWarpOperationH Ptr{Void}
 typealias GDALTransformerFunc Ptr{Void}
 typealias GDALContourWriter Ptr{Void}
-typealias GDALContourGeneratorH Ptr{None}
+typealias GDALContourGeneratorH Ptr{Void}
 # begin enum GDALGridAlgorithm
-typealias GDALGridAlgorithm Uint32
+typealias GDALGridAlgorithm UInt32
 const GGA_InverseDistanceToAPower = 1
 const GGA_MovingAverage = 2
 const GGA_NearestNeighbor = 3
@@ -193,7 +193,7 @@ const GDAL_RELEASE_NAME = "1.10.1"
 typealias GDALGridFunction Ptr{Void}
 const MAX_ULPS = 10
 # begin enum GDALBurnValueSrc
-typealias GDALBurnValueSrc Uint32
+typealias GDALBurnValueSrc UInt32
 const GBV_UserBurnValue = 0
 const GBV_Z = 1
 const GBV_M = 2
@@ -226,22 +226,22 @@ const GPF_AUXMODE = 0x08
 const GPF_NOSAVE = 0x10
 const VRT_NODATA_UNSET = -1234.56
 typealias VRTImageReadFunc Ptr{Void}
-typealias VRTDriverH Ptr{None}
-typealias VRTSourceH Ptr{None}
-typealias VRTSimpleSourceH Ptr{None}
-typealias VRTAveragedSourceH Ptr{None}
-typealias VRTComplexSourceH Ptr{None}
-typealias VRTFilteredSourceH Ptr{None}
-typealias VRTKernelFilteredSourceH Ptr{None}
-typealias VRTAverageFilteredSourceH Ptr{None}
-typealias VRTFuncSourceH Ptr{None}
-typealias VRTDatasetH Ptr{None}
-typealias VRTWarpedDatasetH Ptr{None}
-typealias VRTRasterBandH Ptr{None}
-typealias VRTSourcedRasterBandH Ptr{None}
-typealias VRTWarpedRasterBandH Ptr{None}
-typealias VRTDerivedRasterBandH Ptr{None}
-typealias VRTRawRasterBandH Ptr{None}
+typealias VRTDriverH Ptr{Void}
+typealias VRTSourceH Ptr{Void}
+typealias VRTSimpleSourceH Ptr{Void}
+typealias VRTAveragedSourceH Ptr{Void}
+typealias VRTComplexSourceH Ptr{Void}
+typealias VRTFilteredSourceH Ptr{Void}
+typealias VRTKernelFilteredSourceH Ptr{Void}
+typealias VRTAverageFilteredSourceH Ptr{Void}
+typealias VRTFuncSourceH Ptr{Void}
+typealias VRTDatasetH Ptr{Void}
+typealias VRTWarpedDatasetH Ptr{Void}
+typealias VRTRasterBandH Ptr{Void}
+typealias VRTSourcedRasterBandH Ptr{Void}
+typealias VRTWarpedRasterBandH Ptr{Void}
+typealias VRTDerivedRasterBandH Ptr{Void}
+typealias VRTRawRasterBandH Ptr{Void}
 
 # CPLErr Data Type: added by hand from cplerror.h
 

--- a/src/raster.jl
+++ b/src/raster.jl
@@ -25,13 +25,13 @@ function raster_type_convert(raster_type)
     if raster_type == 0
         raster_jtype = Any
     elseif raster_type == 1
-        raster_jtype = Uint8
+        raster_jtype = UInt8
     elseif raster_type == 2
-        raster_jtype = Uint16
+        raster_jtype = UInt16
     elseif raster_type == 3
         raster_jtype = Int16
     elseif raster_type == 4
-        raster_jtype = Uint32
+        raster_jtype = UInt32
     elseif raster_type == 5
         raster_jtype = Int32
     elseif raster_type == 6


### PR DESCRIPTION
Since Julia 0.4-dev seems to be pretty stable now, I thought it was a good idea to start supporting it.
This adds Julia 0.4 compatability whilst maintaining Julia 0.3 compatability using the Compat package.

Also changes all `Ptr{None}` (renamed in 0.4 to `Ptr{Union{}}`) to `Ptr{Void}`. `Ptr{None}` is used in none of my installed packages, and seemed to be giving problems:

```
julia> convert(Union(), 1)
ERROR: StackOverflowError:
 in convert at ./dates/periods.jl:22
```
