### PR TITLE
Use Conda as binary provider

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: julia
 os:
   - linux
 julia:
-  - release
+  - 0.4
   - nightly
 notifications:
   email: false

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,1 +1,3 @@
 julia 0.4-
+BinDeps
+Conda

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -2,7 +2,7 @@ using BinDeps
 
 @BinDeps.setup
 
-libgdal = library_dependency("libgdal",aliases=["gdal"])
+libgdal = library_dependency("libgdal",aliases=["gdal","gdal200"])
 
 using Conda
 provides(Conda.Manager,"libgdal",libgdal)

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -1,0 +1,11 @@
+using BinDeps
+
+@BinDeps.setup
+
+libgdal = library_dependency("libgdal",aliases=["gdal"])
+
+using Conda
+provides(Conda.Manager,"libgdal",libgdal)
+
+
+@BinDeps.install Dict(:libgdal => :libgdal)

--- a/src/RasterIO.jl
+++ b/src/RasterIO.jl
@@ -1,6 +1,11 @@
 module RasterIO
-
-    const libgdal = "libgdal"
+    using BinDeps
+    const depfile = joinpath(dirname(@__FILE__), "..", "deps", "deps.jl")
+    if isfile(depfile)
+      include(depfile)
+    else
+      error("libgdal not properly installed. Please run Pkg.build(\"RasterIO\")")
+    end
 
     include("gdal_api.jl")
     include("raster_types.jl")


### PR DESCRIPTION
This is a suggestion to use the new package Conda.jl as binary dependeny provider for this package. The ups would be:
- we get libgdal 2.0 binaries
- on all platforms
- without root permission
- I see green on Travis against julia nightlies

which would facilitate testing. We can, of course still define other providers, but then we will get diverse libraries. There are, however, still some problems I want to solve:
- ~~on one of my computers (Linux) Conda does not work due to an SSL error https://github.com/Luthaf/Conda.jl/issues/11 Maybe this is very specific to my machine, so this is not a problem~~
- ~~there is a naming issue that `@BinDeps.load_dependencies defines` a const `libgdal` which we also do in the package. I renamed our `libgdal`, but there must be a better way to solve this.~~
- ~~the installation stiil does not work on WIndows for me, I will continue to test what goes wrong~~

This should in principle work, so tests are welcome, but don't merge yet. 
