### PR TITLE
Remove image structure from REPL display

### DIFF
--- a/src/raster_types.jl
+++ b/src/raster_types.jl
@@ -12,10 +12,6 @@ function Base.show(io::IO, raster::Raster)
         dptr = _getdatasetdriver(raster.dataset)
         driverstring = "$(drivershortname(dptr))/$(driverlongname(dptr))"
         println(io, "RasterIO.Raster (Driver: $driverstring)")
-        print(io, "Image Structure: ")
-        for m in getmetadata(raster.dataset, "IMAGE_STRUCTURE")
-            print(io, "--$m ")
-        end
         print(io, "\nFile(s): ")
         for filename in getfilelist(raster.dataset)
             print(io, "$filename ")


### PR DESCRIPTION
@marciolegal was right afterall, I don't think we should require them:

```
julia> raster = RasterIO.openraster(filename)
RasterIO.Raster (Driver: PNG/Portable Network Graphics)
Metadata: Error showing value of type RasterIO.Raster:
ERROR: Unable to find key AREA_OR_POINT
 in getmetadataitem at /Users/yeesian/.julia/v0.4/RasterIO/src/gdal/utilities.jl:108
 in show at /Users/yeesian/.julia/v0.4/RasterIO/src/raster_types.jl:25
 in anonymous at show.jl:1278
 in with_output_limit at /Applications/Julia-0.4.0.app/Contents/Resources/julia/lib/julia/sys.dylib
 in showlimited at show.jl:1277
 in writemime at replutil.jl:4
 in display at REPL.jl:114
 in display at REPL.jl:117
 in display at multimedia.jl:151
 in print_response at REPL.jl:134
 in print_response at REPL.jl:121
 in anonymous at REPL.jl:624
```

We should also return empty strings rather than error-ing out, but that's left for another time
