### PR TITLE
Search also for newer versions (>= 2.0.x) of GDAL dll on Windows

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -2,7 +2,8 @@ using BinDeps
 
 @BinDeps.setup
 
-libgdal = library_dependency("libgdal",aliases=["gdal","gdal111"])
+sizeof(Int) == 8 ? other_gdal = "gdal_w64" : other_gdal = "gdal_w32"
+libgdal = library_dependency("libgdal",aliases=["gdal","gdal111","gdal201",other_gdal])
 
 using Conda
 @windows_only provides(Conda.Manager,"libgdal==1.11.2",libgdal) #Install older gdal on windows


### PR DESCRIPTION
Add names of the GDAL DLL as currently in http://www.gisinternals.com and the GMT installer
