### PR TITLE
Add precompilation

### DIFF
--- a/src/RasterIO.jl
+++ b/src/RasterIO.jl
@@ -1,3 +1,5 @@
+__precompile__()
+
 module RasterIO
     using Compat
     import Compat.String


### PR DESCRIPTION
This add a `__precompile__()`.  I haven't tested this locally, so let's see.